### PR TITLE
feat: 캡쳐리스트와 웹소켓 데이터 연동 기능 추가 구현

### DIFF
--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -1,23 +1,20 @@
 <template>
-    <div class="card">
-        <DataTable 
-        :value="messages" 
-        id="mytable"
-        size="small"
-        showGridlines 
-        scrollable scrollHeight="100vh"  
-        tableStyle="min-width: 50rem"
-        contextMenu v-model:contextMenuSelection="selectedProduct"
-        >
-            <Column field="number" header="No."></Column>
-            <Column field="time" header="Time"></Column>
-            <Column field="source" header="Source IP"></Column>
-            <Column field="destination" header="Destination IP"></Column>
-            <Column field="protocol" header="Protocol"></Column>
-            <Column field="length" header="Len"></Column>
-            <Column field="info" header="Info"></Column>
-        </DataTable>
-    </div>
+  <div class="card">
+    <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="100vh"
+      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedProduct">
+      <Column field="rowIndex" header="No.">
+        <template #body="{ index }">
+          {{ index + 1 }}
+        </template>
+      </Column>
+      <Column field="seconds_since_beginning" header="Time"></Column>
+      <Column field="source_ip" header="Source IP"></Column>
+      <Column field="destination_ip" header="Destination IP"></Column>
+      <Column field="protocol" header="Protocol"></Column>
+      <Column field="length" header="Len"></Column>
+      <Column field="topic" header="Info"></Column>
+    </DataTable>
+  </div>
 </template>
 
 <script setup>

--- a/src/store/websocketStore.ts
+++ b/src/store/websocketStore.ts
@@ -2,11 +2,21 @@ import { defineStore } from "pinia";
 
 // 수신된 메시지의 타입을 정의하는 인터페이스
 interface Message {
-  type: string;
-  flags: string;
-  length: string;
-  data: string;
-  timestamp: number; // 메시지 수신 시간 추가
+  protocol: string;
+  timestamp: number;
+  time_of_day: number;
+  seconds_since_beginning: number;
+  seconds_since_previous: number;
+  source_ip: string;
+  destination_ip: string;
+  source_port: number;
+  destination_port: number;
+  mqtt_type: string;
+  qos: number;
+  length: number;
+  flags?: number; // 선택적 필드
+  topic?: string; // 선택적 필드
+  value?: string; // 선택적 필드
 }
 
 export const useWebSocketStore = defineStore("websocket", {


### PR DESCRIPTION
<img width="1440" alt="image" src="https://github.com/Wave-Net/wavenet-frontend/assets/52701529/8aa6f53c-80da-4ff8-87c8-ac347b3b7a59">

- 백엔드에서 변경된 json 데이터 형식에 맞춰 websocketStore의 Messages interface 수정
- No. 컬럼값으로 인덱스가 계산되어 들어갈 수 있도록 구현