### PR TITLE
Feat: 패킷 다이어그램로 넘어가는 창 구현

### DIFF
--- a/src/components/PacketDiagram.vue
+++ b/src/components/PacketDiagram.vue
@@ -1,0 +1,21 @@
+<template>
+  <div v-if="selectedRowData">
+    <!-- selectedRowData를 사용하여 대화창 내용을 표시합니다. -->
+    <p> 안녕하세용가리 </p>
+    Len: {{ selectedRowData.length }} <br>
+    qos: {{ selectedRowData.qos }} <br>
+    value: {{ selectedRowData.value }} <br>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    selectedRowData: Object
+  },
+  mounted() {
+    console.log(this.selectedRowData);
+  },
+  // 나머지 코드
+}
+</script>

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="card">
-    <ContextMenu ref="cm" :model="menuModel" @hide="selectedProduct = null" />
+    <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
     <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="95vh"
-      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedProduct"
+      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRow"
       @rowContextmenu="onRowContextMenu">
       <Column field="rowIndex" header="No.">
         <template #body="{ index }">
@@ -18,14 +18,13 @@
     </DataTable>
     <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw' }">
       <!-- 패킷 다이어그램 내용을 여기에 추가하세요 -->
-      <!-- 안녕하세요.<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>메롱 -->
-      <div v-if="selectedProductData">
-        <div>Time: {{ selectedProductData.seconds_since_beginning }}</div>
-        <div>Source IP: {{ selectedProductData.source_ip }}</div>
-        <div>Destination IP: {{ selectedProductData.destination_ip }}</div>
-        <div>Protocol: {{ selectedProductData.protocol }}</div>
-        <div>Len: {{ selectedProductData.length }}</div>
-        <div>Info: {{ selectedProductData.topic }}</div>
+      <div v-if="selectedRowData">
+        <div>Time: {{ selectedRowData.seconds_since_beginning }}</div>
+        <div>Source IP: {{ selectedRowData.source_ip }}</div>
+        <div>Destination IP: {{ selectedRowData.destination_ip }}</div>
+        <div>Protocol: {{ selectedRowData.protocol }}</div>
+        <div>Len: {{ selectedRowData.length }}</div>
+        <div>Info: {{ selectedRowData.topic }}</div>
       </div>
     </Dialog>
   </div>
@@ -41,10 +40,10 @@ import Dialog from 'primevue/dialog';
 
 const websocketStore = useWebSocketStore();
 const cm = ref();
-const selectedProduct = ref();
+const selectedRow = ref();
 const menuModel = ref([
-  { label: '패킷 다이어그램', icon: 'pi pi-objects-column', command: () => viewProduct(selectedProduct) },
-  // {label: '플로우차트', icon: 'pi pi-sliders-h', command: () => deleteProduct(selectedProduct)}
+  { label: '패킷 다이어그램', icon: 'pi pi-objects-column', command: () => viewRow(selectedRow) },
+  // {label: '플로우차트', icon: 'pi pi-sliders-h', command: () => deleteProduct(selectedRow)}
 ]);
 
 // Dialog 표시 상태
@@ -63,22 +62,21 @@ onUnmounted(() => {
 // 메시지 목록 가져오기
 const messages = computed(() => websocketStore.messages);
 
-const selectedProductData = ref(null); // 선택한 행의 데이터를 저장할 ref를 생성합니다.
+const selectedRowData = ref(null); // 선택한 행의 데이터를 저장할 ref를 생성합니다.
 
 const onRowContextMenu = (event) => {
   cm.value.show(event.originalEvent);
 
   //몇번째 인덱스에 위치하는지 찾는 역할로, 각 메세지가 event.data와 동일한지 확인.
-  selectedProduct.value = messages.value.findIndex(message => message === event.data);
-  console.log(selectedProduct.value);
-  selectedProductData.value = messages.value[selectedProduct.value]; // 선택한 행의 데이터를 할당합니다.
+  selectedRow.value = messages.value.findIndex(message => message === event.data);
+  console.log(selectedRow.value);
+  selectedRowData.value = messages.value[selectedRow.value]; // 선택한 행의 데이터를 할당합니다.
 };
 
-const viewProduct = (product) => {
+const viewRow = (rowIndex) => {
   // 여기에 행을 다이어그램화 하는 로직을 추가하세요.
-  // display.value = true;
 
-  if (product !== null) {
+  if (rowIndex !== null) {
     display.value = true;
   } else {
     console.log('행을 선택해주세요.');

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -18,7 +18,15 @@
     </DataTable>
     <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw' }">
       <!-- 패킷 다이어그램 내용을 여기에 추가하세요 -->
-      안녕하세요.<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>메롱
+      <!-- 안녕하세요.<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>메롱 -->
+      <div v-if="selectedProductData">
+        <div>Time: {{ selectedProductData.seconds_since_beginning }}</div>
+        <div>Source IP: {{ selectedProductData.source_ip }}</div>
+        <div>Destination IP: {{ selectedProductData.destination_ip }}</div>
+        <div>Protocol: {{ selectedProductData.protocol }}</div>
+        <div>Len: {{ selectedProductData.length }}</div>
+        <div>Info: {{ selectedProductData.topic }}</div>
+      </div>
     </Dialog>
   </div>
 </template>
@@ -55,13 +63,26 @@ onUnmounted(() => {
 // 메시지 목록 가져오기
 const messages = computed(() => websocketStore.messages);
 
+const selectedProductData = ref(null); // 선택한 행의 데이터를 저장할 ref를 생성합니다.
+
 const onRowContextMenu = (event) => {
   cm.value.show(event.originalEvent);
+
+  //몇번째 인덱스에 위치하는지 찾는 역할로, 각 메세지가 event.data와 동일한지 확인.
+  selectedProduct.value = messages.value.findIndex(message => message === event.data);
+  console.log(selectedProduct.value);
+  selectedProductData.value = messages.value[selectedProduct.value]; // 선택한 행의 데이터를 할당합니다.
 };
 
-const viewProduct = () => {
+const viewProduct = (product) => {
   // 여기에 행을 다이어그램화 하는 로직을 추가하세요.
-  display.value = true;
+  // display.value = true;
+
+  if (product !== null) {
+    display.value = true;
+  } else {
+    console.log('행을 선택해주세요.');
+  }
 };
 
 // const deleteProduct = (product) => {

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -1,23 +1,20 @@
 <template>
-    <div class="card">
-        <DataTable 
-        :value="messages" 
-        id="mytable"
-        size="small"
-        showGridlines 
-        scrollable scrollHeight="100vh"  
-        tableStyle="min-width: 50rem"
-        contextMenu v-model:contextMenuSelection="selectedProduct"
-        >
-            <Column field="number" header="No."></Column>
-            <Column field="time" header="Time"></Column>
-            <Column field="source" header="Source IP"></Column>
-            <Column field="destination" header="Destination IP"></Column>
-            <Column field="protocol" header="Protocol"></Column>
-            <Column field="length" header="Len"></Column>
-            <Column field="info" header="Info"></Column>
-        </DataTable>
-    </div>
+  <div class="card">
+    <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="100vh"
+      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedProduct">
+      <Column field="rowIndex" header="No.">
+        <template #body="{ index }">
+          {{ index + 1 }}
+        </template>
+      </Column>
+      <Column field="seconds_since_beginning" header="Time"></Column>
+      <Column field="source_ip" header="Source IP"></Column>
+      <Column field="destination_ip" header="Destination IP"></Column>
+      <Column field="protocol" header="Protocol"></Column>
+      <Column field="length" header="Len"></Column>
+      <Column field="topic" header="Info"></Column>
+    </DataTable>
+  </div>
 </template>
 
 <script setup>

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -3,7 +3,7 @@
     <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
     <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="95vh"
       tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRowData"
-      @rowContextmenu="onRowContextMenu">
+      @rowContextmenu="onRowContextMenu" rowHover>
       <Column field="rowIndex" header="No.">
         <template #body="{ index }">
           {{ index + 1 }}
@@ -19,12 +19,19 @@
     <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw' }">
       <!-- 패킷 다이어그램 내용을 여기에 추가하세요 -->
       <div v-if="selectedRowData">
-        <div>Time: {{ selectedRowData.seconds_since_beginning }}</div>
+        <!-- <div>Time: {{ selectedRowData.seconds_since_beginning }}</div> -->
         <div>Source IP: {{ selectedRowData.source_ip }}</div>
         <div>Destination IP: {{ selectedRowData.destination_ip }}</div>
+        <div>SrcPort: {{ selectedRowData.source_ip }}</div>
+        <div>DstPort: {{ selectedRowData.destination_ip }}</div>
         <div>Protocol: {{ selectedRowData.protocol }}</div>
         <div>Len: {{ selectedRowData.length }}</div>
-        <div>Info: {{ selectedRowData.topic }}</div>
+        <div>Topic: {{ selectedRowData.topic }}</div>
+        <div>QOS: {{ selectedRowData.qos }}</div>
+        <div>message: {{ selectedRowData.mqtt_type }}</div>
+        <div>value: {{ selectedRowData.value }}</div>
+        <div>flags: {{ selectedRowData.flags }}</div>
+        //info에는 messageType+Topic+value
       </div>
     </Dialog>
   </div>

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -1,32 +1,42 @@
 <template>
-    <div class="card">
-        <DataTable 
-        :value="messages" 
-        id="mytable"
-        size="small"
-        showGridlines 
-        scrollable scrollHeight="100vh"  
-        tableStyle="min-width: 50rem"
-        contextMenu v-model:contextMenuSelection="selectedProduct"
-        >
-            <Column field="number" header="No."></Column>
-            <Column field="time" header="Time"></Column>
-            <Column field="source" header="Source IP"></Column>
-            <Column field="destination" header="Destination IP"></Column>
-            <Column field="protocol" header="Protocol"></Column>
-            <Column field="length" header="Len"></Column>
-            <Column field="info" header="Info"></Column>
-        </DataTable>
-    </div>
+  <div class="card">
+    <ContextMenu ref="cm" :model="menuModel" @hide="selectedProduct = null" />
+    <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="95vh"
+      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedProduct"
+      @rowContextmenu="onRowContextMenu">
+      <Column field="number" header="No."></Column>
+      <Column field="time" header="Time"></Column>
+      <Column field="source" header="Source IP"></Column>
+      <Column field="destination" header="Destination IP"></Column>
+      <Column field="protocol" header="Protocol"></Column>
+      <Column field="length" header="Len"></Column>
+      <Column field="info" header="Info"></Column>
+    </DataTable>
+    <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw' }">
+      <!-- 패킷 다이어그램 내용을 여기에 추가하세요 -->
+      안녕하세요.<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>메롱
+    </Dialog>
+  </div>
 </template>
 
 <script setup>
-import { computed, onMounted, onUnmounted } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useWebSocketStore } from '@/store/websocketStore';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
+import ContextMenu from 'primevue/contextmenu';
+import Dialog from 'primevue/dialog';
 
 const websocketStore = useWebSocketStore();
+const cm = ref();
+const selectedProduct = ref();
+const menuModel = ref([
+  { label: '패킷 다이어그램', icon: 'pi pi-objects-column', command: () => viewProduct(selectedProduct) },
+  // {label: '플로우차트', icon: 'pi pi-sliders-h', command: () => deleteProduct(selectedProduct)}
+]);
+
+// Dialog 표시 상태
+const display = ref(false);
 
 // 웹소켓 연결
 onMounted(() => {
@@ -40,4 +50,17 @@ onUnmounted(() => {
 
 // 메시지 목록 가져오기
 const messages = computed(() => websocketStore.messages);
+
+const onRowContextMenu = (event) => {
+  cm.value.show(event.originalEvent);
+};
+
+const viewProduct = () => {
+  // 여기에 행을 다이어그램화 하는 로직을 추가하세요.
+  display.value = true;
+};
+
+// const deleteProduct = (product) => {
+//   // 여기에 행을 플로우차트화 하는 로직을 추가하세요.
+// };
 </script>

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -17,22 +17,7 @@
       <Column field="topic" header="Info"></Column>
     </DataTable>
     <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw' }">
-      <!-- 패킷 다이어그램 내용을 여기에 추가하세요 -->
-      <div v-if="selectedRowData">
-        <!-- <div>Time: {{ selectedRowData.seconds_since_beginning }}</div> -->
-        <div>Source IP: {{ selectedRowData.source_ip }}</div>
-        <div>Destination IP: {{ selectedRowData.destination_ip }}</div>
-        <div>SrcPort: {{ selectedRowData.source_ip }}</div>
-        <div>DstPort: {{ selectedRowData.destination_ip }}</div>
-        <div>Protocol: {{ selectedRowData.protocol }}</div>
-        <div>Len: {{ selectedRowData.length }}</div>
-        <div>Topic: {{ selectedRowData.topic }}</div>
-        <div>QOS: {{ selectedRowData.qos }}</div>
-        <div>message: {{ selectedRowData.mqtt_type }}</div>
-        <div>value: {{ selectedRowData.value }}</div>
-        <div>flags: {{ selectedRowData.flags }}</div>
-        //info에는 messageType+Topic+value
-      </div>
+      <PacketDiagram :selectedRowData="selectedRowData" />
     </Dialog>
   </div>
 </template>
@@ -44,6 +29,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import ContextMenu from 'primevue/contextmenu';
 import Dialog from 'primevue/dialog';
+import PacketDiagram from './PacketDiagram.vue';
 
 const websocketStore = useWebSocketStore();
 const cm = ref();

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -3,7 +3,7 @@
     <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
     <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="95vh"
       tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRowData"
-      @rowContextmenu="onRowContextMenu" rowHover>
+      @rowContextmenu="onRowContextMenu" rowHover title="더 자세히 보려면 우클릭하세요.">
       <Column field="rowIndex" header="No.">
         <template #body="{ index }">
           {{ index + 1 }}

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -2,7 +2,7 @@
   <div class="card">
     <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
     <DataTable :value="messages" id="mytable" size="small" showGridlines scrollable scrollHeight="95vh"
-      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRow"
+      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRowData"
       @rowContextmenu="onRowContextMenu">
       <Column field="rowIndex" header="No.">
         <template #body="{ index }">

--- a/src/store/websocketStore.ts
+++ b/src/store/websocketStore.ts
@@ -2,11 +2,21 @@ import { defineStore } from "pinia";
 
 // 수신된 메시지의 타입을 정의하는 인터페이스
 interface Message {
-  type: string;
-  flags: string;
-  length: string;
-  data: string;
-  timestamp: number; // 메시지 수신 시간 추가
+  protocol: string;
+  timestamp: number;
+  time_of_day: number;
+  seconds_since_beginning: number;
+  seconds_since_previous: number;
+  source_ip: string;
+  destination_ip: string;
+  source_port: number;
+  destination_port: number;
+  mqtt_type: string;
+  qos: number;
+  length: number;
+  flags?: number; // 선택적 필드
+  topic?: string; // 선택적 필드
+  value?: string; // 선택적 필드
 }
 
 export const useWebSocketStore = defineStore("websocket", {


### PR DESCRIPTION
## issue
#3 

## Details
1. 사용자가 행 우클릭시 '패킷 다이어그램'을 선택할 수 있게 함.
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/39910968-f66c-460c-a19d-7961264e06ed)

2. 창을 띄우면 해당하는 행의 데이터를 출력할 수 있게 함.
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/b32b545f-83c9-4c46-a29f-97ca6e5b7996)

+ 웹소켓 파일 프론트에서 사용할 수 있게 데이터 형태도 조금 수정했습니다!