### PR TITLE
refactor: 변경된 json data 형식에 맞게 PacketMessage, StatMessage, Message 인터페이스 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
           <Splitter style="height:auto" layout="vertical">
             <SplitterPanel class="panel3-1Graph" size="20">
               <!-- 패널 3-1) 선그래프 -->
-              <DashboardGraph :labelData1="'초당 패킷 입력량'" :labelData2="'초당 패킷 출력량'" :labelData3="'초당 데이터 수신량'" :labelData4="'초당 데이터 송신량'" />
+              <!-- <DashboardGraph :labelData1="'초당 패킷 입력량'" :labelData2="'초당 패킷 출력량'" :labelData3="'초당 데이터 수신량'" :labelData4="'초당 데이터 송신량'" /> -->
               
             </SplitterPanel>
 
@@ -38,7 +38,6 @@
 <script>
 import IotPrint from "./components/IotPrint.vue";
 import MenuButton from "./components/MenuButton.vue";
-import DashboardGraph from './components/DashboardGraph.vue';
 import DashboardData from './components/DashboardData.vue';
 import DashboardTimeData from './components/DashboardTimeData.vue';
 import PacketList from './components/PacketList.vue';
@@ -50,7 +49,6 @@ export default {
   components: {
     IotPrint,
     MenuButton,
-    DashboardGraph,
     DashboardData,
     DashboardTimeData,
     PacketList,

--- a/src/components/DashboardGraph.vue
+++ b/src/components/DashboardGraph.vue
@@ -104,7 +104,7 @@ onUnmounted(() => {
 // 데이터 업데이트
 const updateChartData = () => {
   // staticsDelta 객체 확인
-  const { send_pkt, recv_pkt, send_data, recv_data } = store.staticsDelta;
+  const { send_pkt, recv_pkt, send_data, recv_data } = store.statMessage.statDelta;
   
   // 새로운 데이터 추가
   const newChartData = {

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -3,7 +3,7 @@
     <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
 
     <DataTable
-      :value="messages"
+      :value="packetMessages"
       id="mytable"
       size="small"
       showGridlines
@@ -71,7 +71,7 @@ onUnmounted(() => {
 });
 
 // 메시지 목록 가져오기
-const messages = computed(() => websocketStore.messages);
+const packetMessages = computed(() => websocketStore.packetMessages);
 
 const selectedRowData = ref(null); // 선택한 행의 데이터를 저장할 ref를 생성합니다.
 
@@ -79,11 +79,11 @@ const onRowContextMenu = (event) => {
   cm.value.show(event.originalEvent);
 
   //몇번째 인덱스에 위치하는지 찾는 역할로, 각 메세지가 event.data와 동일한지 확인.
-  selectedRow.value = messages.value.findIndex(
+  selectedRow.value = packetMessages.value.findIndex(
     (message) => message === event.data
   );
   console.log(selectedRow.value);
-  selectedRowData.value = messages.value[selectedRow.value]; // 선택한 행의 데이터를 할당합니다.
+  selectedRowData.value = packetMessages.value[selectedRow.value]; // 선택한 행의 데이터를 할당합니다.
 };
 
 const viewRow = (rowIndex) => {

--- a/src/store/websocketStore.ts
+++ b/src/store/websocketStore.ts
@@ -19,7 +19,6 @@ interface StatMessage {
   };
 }
 
-// 수신된 메시지의 타입을 정의하는 인터페이스
 interface PacketMessage {
   // 공통 필드
   index: number;
@@ -56,7 +55,7 @@ interface PacketMessage {
     willflag: number;
     cleansession: number;
     reserved: number;
-    keep_alive: number;
+    keep_alive?: number;
     clientId: string;
     willtopic?: string;
     willmsg?: string;
@@ -67,34 +66,60 @@ interface PacketMessage {
   // MQTT CONNACK 정보
   connack?: {
     ackflag: number;
-    return_code: string;
+    return_code?: number;
   };
 
   // MQTT PUBLISH 정보
   publish?: {
     topic: string;
-    msgid: string;
+    msgid?: number;
     msgvalue: string;
   };
 
   // MQTT PUBACK 정보
   puback?: {
-    msgid: string;
+    msgid: number;
   };
 
   // MQTT PUBREC 정보
   pubrec?: {
-    msgid: string;
+    msgid: number;
   };
 
   // MQTT PUBREL 정보
   pubrel?: {
-    msgid: string;
+    msgid: number;
   };
 
   // MQTT PUBCOMP 정보
   pubcomp?: {
-    msgid: string;
+    msgid: number;
+  };
+  
+  // MQTT SUBSCRIBE 정보
+  subscribe?: {
+    msgid: number;
+    topic_filters: {
+      topic: string;
+      qos: number;
+    }[];
+  };
+  
+  // MQTT SUBACK 정보
+  suback?: {
+    msgid: number;
+    return_code: number;
+  };
+  
+  // MQTT UNSUBSCRIBE 정보
+  unsubscribe?: {
+    msgid: number;
+    topic_filters: string[];
+  };
+  
+  // MQTT UNSUBACK 정보
+  unsuback?: {
+    msgid: number;
   };
 }
 


### PR DESCRIPTION
## Issue
#27 


## Details
서버에서 받은 웹소켓 메시지의 message_type 필드 값에 따라 StatMessage, PacketMessage 인터페이스를 구분하여 저장할 수 있도록 수정
<img width="533" alt="image" src="https://github.com/Wave-Net/wavenet-frontend/assets/52701529/2e88a59a-36b5-4d00-ae0a-59cfb027b341">

패킷 리스트 컴포넌트는 바뀐 값에 맞게 연동이 잘 되었지만
그래프 컴포넌트는 오류 발생. 해결 필요