### PR TITLE
feat: 1바이트 단위로 MQTT 다이어그램 구현

### DIFF
--- a/src/components/DashboardData.vue
+++ b/src/components/DashboardData.vue
@@ -7,39 +7,42 @@
 </template>
 
 <script>
-import { defineComponent, ref, watch } from 'vue';
-import { useWebSocketStore } from '../store/websocketStore';
+import { defineComponent, ref, watch } from "vue";
+import { useWebSocketStore } from "../store/websocketStore";
 
 export default defineComponent({
-  name: 'MyDataTable',
+  name: "MyDataTable",
   setup() {
     const store = useWebSocketStore();
     const products = ref([
-      { name: '패킷 출력 횟수', price: 0, category: 'Category A' },
-      { name: '패킷 입력 횟수', price: 0, category: 'Category B' },
-      { name: '데이터 송신 크기', price: 0, category: 'Category A' },
-      { name: '데이터 수신 크기', price: 0, category: 'Category A' }
+      { name: "패킷 출력 횟수", price: 0, category: "Category A" },
+      { name: "패킷 입력 횟수", price: 0, category: "Category B" },
+      { name: "데이터 송신 크기", price: 0, category: "Category A" },
+      { name: "데이터 수신 크기", price: 0, category: "Category A" },
     ]);
 
     // WebSocket 리스너 설정
-    watch(() => store.totalStatics, (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        // 새로운 데이터가 도착하면 products 배열을 업데이트
-        Object.keys(newValue).forEach((key, index) => {
-          products.value[index].price = newValue[key];
-        });
+    watch(
+      () => store.totalStatics,
+      (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          // 새로운 데이터가 도착하면 products 배열을 업데이트
+          Object.keys(newValue).forEach((key, index) => {
+            products.value[index].price = newValue[key];
+          });
+        }
       }
-    });
+    );
 
     return {
-      products
+      products,
     };
-  }
+  },
 });
 </script>
 
 <style>
-.title-row{
+.title-row {
   background-color: white;
   margin-top: 5px;
   text-align: center;

--- a/src/components/DashboardGraph.vue
+++ b/src/components/DashboardGraph.vue
@@ -1,33 +1,44 @@
 <template>
   <div class="card">
-    <Chart type="line" :data="chartData" :options="chartOptions" class="graph" @legendClick="toggleLineVisibility" />
+    <Chart
+      type="line"
+      :data="chartData"
+      :options="chartOptions"
+      class="graph"
+      @legendClick="toggleLineVisibility"
+    />
   </div>
 </template>
 
 <script setup>
 import { reactive, onMounted, ref } from "vue";
-import { onUnmounted, defineProps } from '@vue/runtime-core';
-import Chart from 'primevue/chart';
+import { onUnmounted, defineProps } from "@vue/runtime-core";
+import Chart from "primevue/chart";
 
-import { useWebSocketStore } from '@/store/websocketStore';
+import { useWebSocketStore } from "@/store/websocketStore";
 
 const store = useWebSocketStore();
 
 // Props 정의
-const props = defineProps(['labelData1', 'labelData2','labelData3','labelData4']);
+const props = defineProps([
+  "labelData1",
+  "labelData2",
+  "labelData3",
+  "labelData4",
+]);
 
 // 데이터 갱신 간격 (밀리초)
 const updateInterval = 1000;
 
 // 초기 차트 데이터 설정
 const chartData = reactive({
-  labels: ['', '', '', '', '', '', ''],
+  labels: ["", "", "", "", "", "", ""],
   datasets: [
     {
       label: props.labelData1,
       data: [0, 0, 0, 0, 0, 0, 0],
       fill: false,
-      borderColor: 'cyan',
+      borderColor: "cyan",
       tension: 0.4,
       borderWidth: 1,
       pointRadius: 2,
@@ -36,7 +47,7 @@ const chartData = reactive({
       label: props.labelData2,
       data: [0, 0, 0, 0, 0, 0, 0],
       fill: false,
-      borderColor: 'gray',
+      borderColor: "gray",
       tension: 0.4,
       borderWidth: 1,
       pointRadius: 2,
@@ -45,7 +56,7 @@ const chartData = reactive({
       label: props.labelData3,
       data: [0, 0, 0, 0, 0, 0, 0],
       fill: false,
-      borderColor: 'orange',
+      borderColor: "orange",
       tension: 0.4,
       borderWidth: 1,
       pointRadius: 2,
@@ -54,21 +65,20 @@ const chartData = reactive({
       label: props.labelData4,
       data: [0, 0, 0, 0, 0, 0, 0],
       fill: false,
-      borderColor: 'pink',
+      borderColor: "pink",
       tension: 0.4,
       borderWidth: 1,
       pointRadius: 2,
     },
   ],
-
 });
 // 차트 옵션 설정
 const chartOptions = reactive({
   maintainAspectRatio: false,
   aspectRatio: 0.6,
-  
+
   // animation 비활성화
-  animation: false
+  animation: false,
 });
 
 // interval ID를 저장할 변수
@@ -86,8 +96,10 @@ const toggleLineVisibility = (event) => {
   const datasetIndex = event.element.datasetIndex;
   const chart = event.chart;
   // 가시성 배열을 토글하여 해당 데이터셋의 가시성을 변경
-  datasetVisibility[datasetIndex].visible = !datasetVisibility[datasetIndex].visible;
-  chart.data.datasets[datasetIndex].hidden = !datasetVisibility[datasetIndex].visible;
+  datasetVisibility[datasetIndex].visible =
+    !datasetVisibility[datasetIndex].visible;
+  chart.data.datasets[datasetIndex].hidden =
+    !datasetVisibility[datasetIndex].visible;
   chart.update();
 };
 
@@ -104,15 +116,16 @@ onUnmounted(() => {
 // 데이터 업데이트
 const updateChartData = () => {
   // staticsDelta 객체 확인
-  const { send_pkt, recv_pkt, send_data, recv_data } = store.statMessage.statDelta;
-  
+  const { send_pkt, recv_pkt, send_data, recv_data } =
+    store.statMessage.statDelta;
+
   // 새로운 데이터 추가
   const newChartData = {
-    labels: [...chartData.labels.slice(1), ''],
+    labels: [...chartData.labels.slice(1), ""],
     datasets: chartData.datasets.map((dataset, index) => {
       let newDataPoint = 0;
       // index에 따라 데이터 설정
-      switch(index) {
+      switch (index) {
         case 0:
           newDataPoint = send_pkt;
           break;
@@ -130,16 +143,15 @@ const updateChartData = () => {
       }
       return {
         ...dataset,
-        data: [...dataset.data.slice(1), newDataPoint]
+        data: [...dataset.data.slice(1), newDataPoint],
       };
-    })
+    }),
   };
 
   // 데이터 반영
   chartData.labels = newChartData.labels;
   chartData.datasets = newChartData.datasets;
 };
-
 </script>
 
 <style>

--- a/src/components/DashboardTimeData.vue
+++ b/src/components/DashboardTimeData.vue
@@ -7,33 +7,36 @@
 </template>
 
 <script>
-import { defineComponent, ref, watch } from 'vue';
-import { useWebSocketStore } from '../store/websocketStore';
+import { defineComponent, ref, watch } from "vue";
+import { useWebSocketStore } from "../store/websocketStore";
 
 export default defineComponent({
-  name: 'MyDataTable',
+  name: "MyDataTable",
   setup() {
     const store = useWebSocketStore();
     const products = ref([
-      { name: '패킷 출력/초', price: 0, category: 'Category A' },
-      { name: '패킷 입력/초', price: 0, category: 'Category B' },
-      { name: '데이터 송신/초', price: 0, category: 'Category A' },
-      { name: '데이터 수신/초', price: 0, category: 'Category A' }
+      { name: "패킷 출력/초", price: 0, category: "Category A" },
+      { name: "패킷 입력/초", price: 0, category: "Category B" },
+      { name: "데이터 송신/초", price: 0, category: "Category A" },
+      { name: "데이터 수신/초", price: 0, category: "Category A" },
     ]);
 
     // WebSocket 리스너 설정
-    watch(() => store.staticsDelta, (newValue, oldValue) => {
-      if (newValue !== oldValue) {
-        // 새로운 데이터가 도착하면 products 배열을 업데이트
-        Object.keys(newValue).forEach((key, index) => {
-          products.value[index].price = newValue[key];
-        });
+    watch(
+      () => store.staticsDelta,
+      (newValue, oldValue) => {
+        if (newValue !== oldValue) {
+          // 새로운 데이터가 도착하면 products 배열을 업데이트
+          Object.keys(newValue).forEach((key, index) => {
+            products.value[index].price = newValue[key];
+          });
+        }
       }
-    });
+    );
 
     return {
-      products
+      products,
     };
-  }
+  },
 });
 </script>

--- a/src/components/IotPrint.vue
+++ b/src/components/IotPrint.vue
@@ -3,32 +3,40 @@
         <p><img src="@/assets/wavenetLogo.png" alt="wavenet프로그램 로고이미지" style="width:27px; height: 27;"> {{ iotAddress }}</p>
     </div> -->
 
-  <div style="display: flex; align-items: center;">
-    <img class="waveimg" src="@/assets/wavenetLogo.png" alt="wavenet프로그램 로고이미지">
+  <div style="display: flex; align-items: center">
+    <img
+      class="waveimg"
+      src="@/assets/wavenetLogo.png"
+      alt="wavenet프로그램 로고이미지"
+    />
     <p class="adress">{{ iotAddress }}</p>
-    <div class="memoryDashboard" style="display: flex; align-items: center;">
+    <div class="memoryDashboard" style="display: flex; align-items: center">
       메모리:
-      <Knob class="memoryCheck" v-model="value" :size="40" valueTemplate="{value}%" /> <!--readonly 안에 넣으면 값 수정할 수 없음.-->
+      <Knob
+        class="memoryCheck"
+        v-model="value"
+        :size="40"
+        valueTemplate="{value}%"
+      />
+      <!--readonly 안에 넣으면 값 수정할 수 없음.-->
     </div>
   </div>
 </template>
 
 <script>
-import Knob from 'primevue/knob';
+import Knob from "primevue/knob";
 
 export default {
   components: {
     Knob,
   },
   data() {
-
-
     return {
-      iotAddress: '192.255.255.255',
+      iotAddress: "192.255.255.255",
       value: 20,
-    }
+    };
   },
-}
+};
 </script>
 
 <style scoped>

--- a/src/components/MenuButton.vue
+++ b/src/components/MenuButton.vue
@@ -1,34 +1,44 @@
 <template>
   <div>
-    <ToggleButton v-model="captureButtonState" onLabel="중단" offLabel="시작" onIcon="pi pi-stop-circle"
-      offIcon="pi pi-play-circle" class="startButton" @change="handleCaptureToggle" />
-    <SplitButton label="데이터내보내기" :model="items" :disabled="captureButtonState" class="dataPrint">
-      <i class="pi pi-download"><span style="padding-left: 5px;">데이터 내보내기</span></i>
+    <ToggleButton
+      v-model="captureButtonState"
+      onLabel="중단"
+      offLabel="시작"
+      onIcon="pi pi-stop-circle"
+      offIcon="pi pi-play-circle"
+      class="startButton"
+      @change="handleCaptureToggle"
+    />
+    <SplitButton
+      label="데이터내보내기"
+      :model="items"
+      :disabled="captureButtonState"
+      class="dataPrint"
+    >
+      <i class="pi pi-download"
+        ><span style="padding-left: 5px">데이터 내보내기</span></i
+      >
     </SplitButton>
   </div>
 </template>
 
 <script setup>
-import ToggleButton from 'primevue/togglebutton';
-import SplitButton from 'primevue/splitbutton';
-import 'primeicons/primeicons.css'
-import { useWebSocketStore } from '@/store/websocketStore';
-import { ref } from 'vue';
+import ToggleButton from "primevue/togglebutton";
+import SplitButton from "primevue/splitbutton";
+import "primeicons/primeicons.css";
+import { useWebSocketStore } from "@/store/websocketStore";
+import { ref } from "vue";
 
 const websocketStore = useWebSocketStore();
 const captureButtonState = ref(false);
-const items = [
-  { label: "PCAP" },
-  { label: "JSON" },
-  { label: "CSV" }
-];
+const items = [{ label: "PCAP" }, { label: "JSON" }, { label: "CSV" }];
 
 const handleCaptureToggle = () => {
   if (captureButtonState.value) {
-    console.log('capture start');
+    console.log("capture start");
     websocketStore.startCapture();
   } else {
-    console.log('capture stop');
+    console.log("capture stop");
     websocketStore.stopCapture();
   }
 };

--- a/src/components/PacketDiagram.vue
+++ b/src/components/PacketDiagram.vue
@@ -1,76 +1,217 @@
 <template>
   <!-- selectedRowData를 사용하여 대화창 내용을 표시합니다. -->
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.2px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.1px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
-  <div style="border-bottom: solid 0.1px; border-left: solid 0.1px; border-right: solid 0.2px; width: 12.5%; float: left; padding-bottom: 2%;"></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.2px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.1px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
+  <div
+    style="
+      border-bottom: solid 0.1px;
+      border-left: solid 0.1px;
+      border-right: solid 0.2px;
+      width: 12.5%;
+      float: left;
+      padding-bottom: 2%;
+    "
+  ></div>
 
   <div v-if="pkt.name == 'MQTT'">
     <!-- MQTT_fixed Header -->
-    <p class="key-txt bit-4">Type<br><span class="val-txt">{{ pkt.type }}</span></p>
-    <p class="key-txt bit-1">Dup<br><span class="val-txt">{{ pkt.header.dup }}</span></p>
-    <p class="key-txt bit-2">QoS<br><span class="val-txt">{{ pkt.header.qos }}</span></p>
-    <p class="key-txt bit-1">Retain<br><span class="val-txt">{{ pkt.header.retain }}</span></p>
-    <p class="key-txt byte-1">Len<br><span class="val-txt">{{ pkt.header.msg_len }}</span></p>
+    <p class="key-txt bit-4">
+      Type<br /><span class="val-txt">{{ pkt.type }}</span>
+    </p>
+    <p class="key-txt bit-1">
+      Dup<br /><span class="val-txt">{{ pkt.header.dup }}</span>
+    </p>
+    <p class="key-txt bit-2">
+      QoS<br /><span class="val-txt">{{ pkt.header.qos }}</span>
+    </p>
+    <p class="key-txt bit-1">
+      Retain<br /><span class="val-txt">{{ pkt.header.retain }}</span>
+    </p>
+    <p class="key-txt byte-1">
+      Len<br /><span class="val-txt">{{ pkt.header.msg_len }}</span>
+    </p>
 
     <!-- MQTT_CONNECT -->
     <div v-if="pkt.type == 'CONNECT'">
-      <p class="key-txt byte-4">Protocol<br><span class="val-txt">{{ pkt.connect.proto_name }}</span></p>
-      <p class="key-txt byte-1">Version<br><span class="val-txt">{{ pkt.connect.mqtt_level }}</span></p>
-      <p class="key-txt bit-1">UsernameFlag<br><span class="val-txt">{{ pkt.connect.usernameflag }}</span></p>
-      <p class="key-txt bit-1">PwFlag<br><span class="val-txt">{{ pkt.connect.passwordflag }}</span></p>
-      <p class="key-txt bit-1">WillRetainFlag<br><span class="val-txt">{{ pkt.connect.willretainflag }}</span></p>
-      <p class="key-txt bit-2">WillQosFlag<br><span class="val-txt">{{ pkt.connect.willQOSflag }}</span></p>
-      <p class="key-txt bit-1">WillFlag<br><span class="val-txt">{{ pkt.connect.willflag }}</span></p>
-      <p class="key-txt bit-1">Cleansession<br><span class="val-txt">{{ pkt.connect.cleansession }}</span></p>
-      <p class="key-txt bit-1">Reserved<br><span class="val-txt">{{ pkt.connect.reserved }}</span></p>
-      <p class="key-txt byte-2">KeepAlive<br><span class="val-txt">{{ pkt.connect.keep_alive }}</span></p>
-      <p class="key-txt">ClientID<br><span class="val-txt">{{ pkt.connect.clientId }}</span></p>
-      
-      <p v-if="pkt.connect.willflag" class="key-txt">WillTopic<br><span class="val-txt">{{ pkt.connect.willtopic }}</span></p>
-      <p v-if="pkt.connect.willflag" class="key-txt">Willmsg<br><span class="val-txt">{{ pkt.connect.willmsg }}</span></p>
-      <p v-if="pkt.connect.usernameflag" class="key-txt">UserName<br><span class="val-txt">{{ pkt.connect.username }}</span></p>
-      <p v-if="pkt.connect.passwordflag" class="key-txt">Password<br><span class="val-txt">{{ pkt.connect.password }}</span></p>
+      <p class="key-txt byte-4">
+        Protocol<br /><span class="val-txt">{{ pkt.connect.proto_name }}</span>
+      </p>
+      <p class="key-txt byte-1">
+        Version<br /><span class="val-txt">{{ pkt.connect.mqtt_level }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        UsernameFlag<br /><span class="val-txt">{{
+          pkt.connect.usernameflag
+        }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        PwFlag<br /><span class="val-txt">{{ pkt.connect.passwordflag }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        WillRetainFlag<br /><span class="val-txt">{{
+          pkt.connect.willretainflag
+        }}</span>
+      </p>
+      <p class="key-txt bit-2">
+        WillQosFlag<br /><span class="val-txt">{{
+          pkt.connect.willQOSflag
+        }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        WillFlag<br /><span class="val-txt">{{ pkt.connect.willflag }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        Cleansession<br /><span class="val-txt">{{
+          pkt.connect.cleansession
+        }}</span>
+      </p>
+      <p class="key-txt bit-1">
+        Reserved<br /><span class="val-txt">{{ pkt.connect.reserved }}</span>
+      </p>
+      <p class="key-txt byte-2">
+        KeepAlive<br /><span class="val-txt">{{ pkt.connect.keep_alive }}</span>
+      </p>
+      <p class="key-txt">
+        ClientID<br /><span class="val-txt">{{ pkt.connect.clientId }}</span>
+      </p>
+
+      <p v-if="pkt.connect.willflag" class="key-txt">
+        WillTopic<br /><span class="val-txt">{{ pkt.connect.willtopic }}</span>
+      </p>
+      <p v-if="pkt.connect.willflag" class="key-txt">
+        Willmsg<br /><span class="val-txt">{{ pkt.connect.willmsg }}</span>
+      </p>
+      <p v-if="pkt.connect.usernameflag" class="key-txt">
+        UserName<br /><span class="val-txt">{{ pkt.connect.username }}</span>
+      </p>
+      <p v-if="pkt.connect.passwordflag" class="key-txt">
+        Password<br /><span class="val-txt">{{ pkt.connect.password }}</span>
+      </p>
     </div>
 
     <!-- MQTT_CONNACK -->
     <div v-if="pkt.type == 'CONNACK'">
-      <p class="key-txt byte-1">AckFlag<br><span class="val-txt">{{ pkt.connack.ackflag }}</span></p>
-      <p class="key-txt byte-1">ReturnCode<br><span class="val-txt">{{ pkt.connack.return_code }}</span></p>
+      <p class="key-txt byte-1">
+        AckFlag<br /><span class="val-txt">{{ pkt.connack.ackflag }}</span>
+      </p>
+      <p class="key-txt byte-1">
+        ReturnCode<br /><span class="val-txt">{{
+          pkt.connack.return_code
+        }}</span>
+      </p>
     </div>
 
     <!-- MQTT_PUBLISH -->
     <div v-if="pkt.type == 'PUBLISH'">
-      <p class="key-txt">Topic<br><span class="val-txt">{{ pkt.publish.topic }}</span></p>
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.publish.msgid }}</span></p>
-      <p class="key-txt">Message<br><span class="val-txt">{{ pkt.publish.msgvalue }}</span></p>
+      <p class="key-txt">
+        Topic<br /><span class="val-txt">{{ pkt.publish.topic }}</span>
+      </p>
+      <p class="key-txt byte-2">
+        MsgID<br /><span class="val-txt">{{ pkt.publish.msgid }}</span>
+      </p>
+      <p class="key-txt">
+        Message<br /><span class="val-txt">{{ pkt.publish.msgvalue }}</span>
+      </p>
     </div>
 
     <!-- MQTT_PUBACK -->
     <div v-if="pkt.type == 'PUBACK'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.puback.msgid }}</span></p>
+      <p class="key-txt byte-2">
+        MsgID<br /><span class="val-txt">{{ pkt.puback.msgid }}</span>
+      </p>
     </div>
 
     <!-- MQTT_PUBREC -->
     <div v-if="pkt.type == 'PUBREC'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.pubrec.msgid }}</span></p>
+      <p class="key-txt byte-2">
+        MsgID<br /><span class="val-txt">{{ pkt.pubrec.msgid }}</span>
+      </p>
     </div>
 
     <!-- MQTT_PUBREL -->
     <div v-if="pkt.type == 'PUBREL'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.pubrel.msgid }}</span></p>
+      <p class="key-txt byte-2">
+        MsgID<br /><span class="val-txt">{{ pkt.pubrel.msgid }}</span>
+      </p>
     </div>
 
     <!-- MQTT_PUBCOMP -->
     <div v-if="pkt.type == 'PUBCOMP'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.pubcomp.msgid }}</span></p>
+      <p class="key-txt byte-2">
+        MsgID<br /><span class="val-txt">{{ pkt.pubcomp.msgid }}</span>
+      </p>
     </div>
 
-    <!-- MQTT_SUBSCRIBE --> <!--topic len에 따라서 크기가 달라질텐데 계산 해봐야할듯-->
+    <!-- MQTT_SUBSCRIBE -->
+    <!--topic len에 따라서 크기가 달라질텐데 계산 해봐야할듯-->
     <!-- <div v-if="pkt.type == 'SUBSCRIBE'">
       <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.msgid }}</span></p>
       <div v-for="item in pkt.subscribe">
@@ -97,13 +238,13 @@
 <script>
 export default {
   props: {
-    pkt: Object
+    pkt: Object,
   },
   mounted() {
     console.log(this.pkt);
   },
   // 나머지 코드
-}
+};
 </script>
 
 <style scoped>
@@ -131,7 +272,7 @@ p {
   width: 12.5%;
   height: 36px;
 }
-.bit-2{
+.bit-2 {
   width: 25%;
   height: 36px;
 }
@@ -147,7 +288,7 @@ p {
   width: 100%;
   height: 72px;
 }
-.byte-4{
+.byte-4 {
   width: 100%;
   height: 144px;
 }

--- a/src/components/PacketDiagram.vue
+++ b/src/components/PacketDiagram.vue
@@ -1,237 +1,239 @@
 <template>
-  <!-- selectedRowData를 사용하여 대화창 내용을 표시합니다. -->
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.2px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.1px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
-  <div
-    style="
-      border-bottom: solid 0.1px;
-      border-left: solid 0.1px;
-      border-right: solid 0.2px;
-      width: 12.5%;
-      float: left;
-      padding-bottom: 2%;
-    "
-  ></div>
+  <div class="wrap-diagram">
+    <div class="bit-left"></div>
+    <div class="bit-middle" v-for="(item, i) in 6" :key="i"></div>
+    <div class="bit-right"></div>
 
-  <div v-if="pkt.name == 'MQTT'">
-    <!-- MQTT_fixed Header -->
-    <p class="key-txt bit-4">
-      Type<br /><span class="val-txt">{{ pkt.type }}</span>
-    </p>
-    <p class="key-txt bit-1">
-      Dup<br /><span class="val-txt">{{ pkt.header.dup }}</span>
-    </p>
-    <p class="key-txt bit-2">
-      QoS<br /><span class="val-txt">{{ pkt.header.qos }}</span>
-    </p>
-    <p class="key-txt bit-1">
-      Retain<br /><span class="val-txt">{{ pkt.header.retain }}</span>
-    </p>
-    <p class="key-txt byte-1">
-      Len<br /><span class="val-txt">{{ pkt.header.msg_len }}</span>
-    </p>
-
-    <!-- MQTT_CONNECT -->
-    <div v-if="pkt.type == 'CONNECT'">
-      <p class="key-txt byte-4">
-        Protocol<br /><span class="val-txt">{{ pkt.connect.proto_name }}</span>
-      </p>
-      <p class="key-txt byte-1">
-        Version<br /><span class="val-txt">{{ pkt.connect.mqtt_level }}</span>
+    <div v-if="pkt.name == 'MQTT'">
+      <!-- MQTT_fixed Header -->
+      <p class="key-txt bit-4">
+        Type<br /><span class="val-txt">{{ pkt.type }}</span>
       </p>
       <p class="key-txt bit-1">
-        UsernameFlag<br /><span class="val-txt">{{
-          pkt.connect.usernameflag
-        }}</span>
-      </p>
-      <p class="key-txt bit-1">
-        PwFlag<br /><span class="val-txt">{{ pkt.connect.passwordflag }}</span>
-      </p>
-      <p class="key-txt bit-1">
-        WillRetainFlag<br /><span class="val-txt">{{
-          pkt.connect.willretainflag
-        }}</span>
+        Dup<br /><span class="val-txt">{{ pkt.header.dup }}</span>
       </p>
       <p class="key-txt bit-2">
-        WillQosFlag<br /><span class="val-txt">{{
-          pkt.connect.willQOSflag
-        }}</span>
+        QoS<br /><span class="val-txt">{{ pkt.header.qos }}</span>
       </p>
       <p class="key-txt bit-1">
-        WillFlag<br /><span class="val-txt">{{ pkt.connect.willflag }}</span>
-      </p>
-      <p class="key-txt bit-1">
-        Cleansession<br /><span class="val-txt">{{
-          pkt.connect.cleansession
-        }}</span>
-      </p>
-      <p class="key-txt bit-1">
-        Reserved<br /><span class="val-txt">{{ pkt.connect.reserved }}</span>
-      </p>
-      <p class="key-txt byte-2">
-        KeepAlive<br /><span class="val-txt">{{ pkt.connect.keep_alive }}</span>
-      </p>
-      <p class="key-txt">
-        ClientID<br /><span class="val-txt">{{ pkt.connect.clientId }}</span>
-      </p>
-
-      <p v-if="pkt.connect.willflag" class="key-txt">
-        WillTopic<br /><span class="val-txt">{{ pkt.connect.willtopic }}</span>
-      </p>
-      <p v-if="pkt.connect.willflag" class="key-txt">
-        Willmsg<br /><span class="val-txt">{{ pkt.connect.willmsg }}</span>
-      </p>
-      <p v-if="pkt.connect.usernameflag" class="key-txt">
-        UserName<br /><span class="val-txt">{{ pkt.connect.username }}</span>
-      </p>
-      <p v-if="pkt.connect.passwordflag" class="key-txt">
-        Password<br /><span class="val-txt">{{ pkt.connect.password }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_CONNACK -->
-    <div v-if="pkt.type == 'CONNACK'">
-      <p class="key-txt byte-1">
-        AckFlag<br /><span class="val-txt">{{ pkt.connack.ackflag }}</span>
+        Retain<br /><span class="val-txt">{{ pkt.header.retain }}</span>
       </p>
       <p class="key-txt byte-1">
-        ReturnCode<br /><span class="val-txt">{{
-          pkt.connack.return_code
-        }}</span>
+        Remaing Len<br /><span class="val-txt">{{ pkt.header.msg_len }}</span>
       </p>
-    </div>
 
-    <!-- MQTT_PUBLISH -->
-    <div v-if="pkt.type == 'PUBLISH'">
-      <p class="key-txt">
-        Topic<br /><span class="val-txt">{{ pkt.publish.topic }}</span>
-      </p>
-      <p class="key-txt byte-2">
-        MsgID<br /><span class="val-txt">{{ pkt.publish.msgid }}</span>
-      </p>
-      <p class="key-txt">
-        Message<br /><span class="val-txt">{{ pkt.publish.msgvalue }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_PUBACK -->
-    <div v-if="pkt.type == 'PUBACK'">
-      <p class="key-txt byte-2">
-        MsgID<br /><span class="val-txt">{{ pkt.puback.msgid }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_PUBREC -->
-    <div v-if="pkt.type == 'PUBREC'">
-      <p class="key-txt byte-2">
-        MsgID<br /><span class="val-txt">{{ pkt.pubrec.msgid }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_PUBREL -->
-    <div v-if="pkt.type == 'PUBREL'">
-      <p class="key-txt byte-2">
-        MsgID<br /><span class="val-txt">{{ pkt.pubrel.msgid }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_PUBCOMP -->
-    <div v-if="pkt.type == 'PUBCOMP'">
-      <p class="key-txt byte-2">
-        MsgID<br /><span class="val-txt">{{ pkt.pubcomp.msgid }}</span>
-      </p>
-    </div>
-
-    <!-- MQTT_SUBSCRIBE -->
-    <!--topic len에 따라서 크기가 달라질텐데 계산 해봐야할듯-->
-    <!-- <div v-if="pkt.type == 'SUBSCRIBE'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.msgid }}</span></p>
-      <div v-for="item in pkt.subscribe">
-        <p class="key-txt">Topic<span class="val-txt">{{ item.topic }}</span></p>
-        <p class="key-txt byte-1">Qos<span class="val-txt">{{ item.qos }}</span></p>      
+      <!-- MQTT_CONNECT -->
+      <div v-if="pkt.type == 'CONNECT'">
+        <p class="key-txt byte-2">
+          ProtocolNameLength<br /><span class="val-txt">{{
+            pkt.connect.proto_name.length - 3
+          }}</span>
+        </p>
+        <p class="key-txt byte-4">
+          Protocol<br /><span class="val-txt">{{
+            pkt.connect.proto_name
+          }}</span>
+        </p>
+        <p class="key-txt byte-1">
+          Version<br /><span class="val-txt">{{ pkt.connect.mqtt_level }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          UsernameFlag<br /><span class="val-txt">{{
+            pkt.connect.usernameflag
+          }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          PwFlag<br /><span class="val-txt">{{
+            pkt.connect.passwordflag
+          }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          WillRetainFlag<br /><span class="val-txt">{{
+            pkt.connect.willretainflag
+          }}</span>
+        </p>
+        <p class="key-txt bit-2">
+          WillQosFlag<br /><span class="val-txt">{{
+            pkt.connect.willQOSflag
+          }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          WillFlag<br /><span class="val-txt">{{ pkt.connect.willflag }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          Cleansession<br /><span class="val-txt">{{
+            pkt.connect.cleansession
+          }}</span>
+        </p>
+        <p class="key-txt bit-1">
+          Reserved<br /><span class="val-txt">{{ pkt.connect.reserved }}</span>
+        </p>
+        <p class="key-txt byte-2">
+          KeepAlive<br /><span class="val-txt">{{
+            pkt.connect.keep_alive
+          }}</span>
+        </p>
+        <p class="key-txt byte-2">
+          ClientIdLength<br /><span class="val-txt">{{
+            pkt.connect.clientId.length - 3
+          }}</span>
+        </p>
+        <p class="key-txt byte-non">
+          ClientID ({{ pkt.connect.clientId.length - 3 }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.connect.clientId }}</span
+          >
+        </p>
+        <p v-if="pkt.connect.willflag" class="key-txt byte-non">
+          WillTopic ({{ pkt.connect.willtopic.length }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.connect.willtopic }}</span
+          >
+        </p>
+        <p v-if="pkt.connect.willflag" class="key-txt byte-non">
+          Willmsg ({{ pkt.connect.willmsg.length }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.connect.willmsg }}</span
+          >
+        </p>
+        <p v-if="pkt.connect.usernameflag" class="key-txt byte-non">
+          UserName ({{ pkt.connect.username.length }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.connect.username }}</span
+          >
+        </p>
+        <p v-if="pkt.connect.passwordflag" class="key-txt byte-non">
+          Password ({{ pkt.connect.password.length }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.connect.password }}</span
+          >
+        </p>
       </div>
-    </div> -->
 
-    <!-- MQTT_SUBACK -->
-    <!-- <div v-if="pkt.type == 'SUBACK'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.suback.msgid }}</span></p>
-      <p class="key-txt byte-2">returnCode<br><span class="val-txt">{{ pkt.suback.returncode }}</span></p>
-    </div> -->
+      <!-- MQTT_CONNACK -->
+      <div v-if="pkt.type == 'CONNACK'">
+        <p class="key-txt byte-1">
+          AckFlag<br /><span class="val-txt">{{ pkt.connack.ackflag }}</span>
+        </p>
+        <p class="key-txt byte-1">
+          ReturnCode<br /><span class="val-txt">{{
+            pkt.connack.return_code
+          }}</span>
+        </p>
+      </div>
 
-    <!-- MQTT_UNSUBSCRIBE -->
+      <!-- MQTT_PUBLISH -->
+      <div v-if="pkt.type == 'PUBLISH'">
+        <p class="key-txt byte-2">
+          TopicLen<br /><span class="val-txt">{{
+            pkt.publish.topic.length - 3
+          }}</span>
+        </p>
+        <p class="key-txt byte-non">
+          Topic ({{ pkt.publish.topic.length - 3 }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.publish.topic }}</span
+          >
+        </p>
+        <p v-if="pkt.publish.msgid" class="key-txt byte-2">
+          <!--Qos==0이면 msgid는 없음-->
+          MsgID<br /><span class="val-txt">{{ pkt.publish.msgid }}</span>
+        </p>
+        <p class="key-txt byte-non">
+          Message ({{ pkt.publish.msgvalue.length - 3 }} byte)<br /><span
+            class="val-txt"
+            >{{ pkt.publish.msgvalue }}</span
+          >
+        </p>
+      </div>
 
-    <!-- MQTT_UNSUBACK -->
-    <!-- <div v-if="pkt.type=='UNSUBACK'">
-      <p class="key-txt byte-2">MsgID<br><span class="val-txt">{{ pkt.unsuback.msgid }}</span></p>
-    </div> -->
+      <!-- MQTT_PUBACK -->
+      <div v-if="pkt.type == 'PUBACK'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.puback.msgid }}</span>
+        </p>
+      </div>
+
+      <!-- MQTT_PUBREC -->
+      <div v-if="pkt.type == 'PUBREC'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.pubrec.msgid }}</span>
+        </p>
+      </div>
+
+      <!-- MQTT_PUBREL -->
+      <div v-if="pkt.type == 'PUBREL'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.pubrel.msgid }}</span>
+        </p>
+      </div>
+
+      <!-- MQTT_PUBCOMP -->
+      <div v-if="pkt.type == 'PUBCOMP'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.pubcomp.msgid }}</span>
+        </p>
+      </div>
+
+      <!-- MQTT_SUBSCRIBE -->
+      <div v-if="pkt.type == 'SUBSCRIBE'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.subscribe.msgid }}</span>
+        </p>
+        <div v-for="(item, index) in pkt.subscribe.topic_filters" :key="index">
+          <p class="key-txt byte-2">
+            TopicLen<br /><span class="val-txt">{{ item.topic.length }}</span>
+          </p>
+          <p class="key-txt byte-non">
+            Topic ({{ item.topic.length }} byte)<br /><span class="val-txt">{{
+              item.topic
+            }}</span>
+          </p>
+          <p class="key-txt byte-1">
+            Qos<br /><span class="val-txt">{{ item.qos }}</span>
+          </p>
+        </div>
+      </div>
+
+      <!-- MQTT_SUBACK -->
+      <div v-if="pkt.type == 'SUBACK'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.suback.msgid }}</span>
+        </p>
+        <p class="key-txt byte-1">
+          returnCode<br /><span class="val-txt">{{
+            pkt.suback.return_code
+          }}</span>
+        </p>
+      </div>
+
+      <!-- MQTT_UNSUBSCRIBE -->
+      <div v-if="pkt.type == 'UNSUBSCRIBE'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.unsubscribe.msgid }}</span>
+        </p>
+        <div
+          v-for="(item, index) in pkt.unsubscribe.topic_filters"
+          :key="index"
+        >
+          <p class="key-txt byte-2">
+            TopicLen<br /><span class="val-txt">{{ item.topic.length }}</span>
+          </p>
+          <p class="key-txt byte-non">
+            Topic ({{ item.topic.length }} byte)<br /><span class="val-txt">{{
+              item.topic
+            }}</span>
+          </p>
+        </div>
+      </div>
+
+      <!-- MQTT_UNSUBACK -->
+      <div v-if="pkt.type == 'UNSUBACK'">
+        <p class="key-txt byte-2">
+          MsgID<br /><span class="val-txt">{{ pkt.unsuback.msgid }}</span>
+        </p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -291,5 +293,42 @@ p {
 .byte-4 {
   width: 100%;
   height: 144px;
+}
+.byte-non {
+  width: 100%;
+  height: auto;
+}
+.bit-left {
+  box-sizing: border-box;
+  border-bottom: solid 0.1px;
+  border-left: 0.1px solid;
+  border-right: solid 0.1px;
+  width: 12.5%;
+  float: left;
+  padding-bottom: 2%;
+}
+.bit-middle {
+  box-sizing: border-box;
+  border-bottom: solid 0.1px;
+  border-left: solid 0.1px;
+  border-right: solid 0.1px;
+  width: 12.5%;
+  float: left;
+  padding-bottom: 2%;
+}
+.bit-right {
+  box-sizing: border-box;
+  border-bottom: solid 0.1px;
+  border-left: solid 0.1px;
+  border-right: solid 0.1px;
+  width: 12.5%;
+  float: left;
+  padding-bottom: 2%;
+}
+
+.wrap-diagram {
+  float: none;
+  box-sizing: border-box;
+  width: 100%;
 }
 </style>

--- a/src/components/PacketList.vue
+++ b/src/components/PacketList.vue
@@ -2,9 +2,20 @@
   <div class="card">
     <ContextMenu ref="cm" :model="menuModel" @hide="selectedRow = null" />
 
-    <DataTable :value="packetMessages" id="mytable" size="small" showGridlines scrollable scrollHeight="97vh"
-      tableStyle="min-width: 50rem" contextMenu v-model:contextMenuSelection="selectedRowData"
-      @rowContextmenu="onRowContextMenu" rowHover title="더 자세히 보려면 우클릭하세요.">
+    <DataTable
+      :value="packetMessages"
+      id="mytable"
+      size="small"
+      showGridlines
+      scrollable
+      scrollHeight="97vh"
+      tableStyle="min-width: 50rem"
+      contextMenu
+      v-model:contextMenuSelection="selectedRowData"
+      @rowContextmenu="onRowContextMenu"
+      rowHover
+      title="더 자세히 보려면 우클릭하세요."
+    >
       <Column field="index" header="No."></Column>
       <Column field="seconds_since_beginning" header="Time"></Column>
       <Column field="source_ip" header="Source IP"></Column>
@@ -14,7 +25,12 @@
       <Column field="type" header="Info"></Column>
       <!-- 수정해야할듯 -->
     </DataTable>
-    <Dialog v-model:visible="display" :modal="true" header="패킷 다이어그램" :style="{ width: '50vw', minWidth: '633.8px' }">
+    <Dialog
+      v-model:visible="display"
+      :modal="true"
+      header="패킷 다이어그램"
+      :style="{ width: '50vw', minWidth: '633.8px' }"
+    >
       <PacketDiagram :pkt="selectedRowData" />
     </Dialog>
   </div>

--- a/src/page/capture-page.vue
+++ b/src/page/capture-page.vue
@@ -9,7 +9,8 @@
       </div>
       <div id="dashboard-graph" class="dashboard-graph">
         <!-- <DashboardGraph /> -->
-      </div> <!--label넣기-->
+      </div>
+      <!--label넣기-->
       <div id="dashboard-data" class="dashboard-data">
         <DashboardData />
       </div>
@@ -29,9 +30,9 @@
 import IotPrint from "../components/IotPrint.vue";
 import MenuButton from "../components/MenuButton.vue";
 // import DashboardGraph from '../components/DashboardGraph.vue';
-import DashboardData from '../components/DashboardData.vue';
-import DashboardTimeData from '../components/DashboardTimeData.vue';
-import PacketList from '../components/PacketList.vue';
+import DashboardData from "../components/DashboardData.vue";
+import DashboardTimeData from "../components/DashboardTimeData.vue";
+import PacketList from "../components/PacketList.vue";
 
 export default {
   components: {
@@ -46,7 +47,7 @@ export default {
 </script>
 
 <style>
-.pkt-list{
+.pkt-list {
   margin-left: 5px;
   background-color: whitesmoke;
   border-radius: 5px;
@@ -57,50 +58,49 @@ export default {
   margin-top: 5px;
   border-radius: 5px;
 }
-.dashboard-timedata{
+.dashboard-timedata {
   box-sizing: border-box;
   height: 153.6px;
   margin-top: 5px;
   border-radius: 5px;
 }
-.dashboard-graph{
+.dashboard-graph {
   box-sizing: border-box;
   height: auto;
   background-color: white;
   margin-top: 5px;
   border-radius: 5px;
 }
-.menu-button-bar{
+.menu-button-bar {
   box-sizing: border-box;
   height: 40px;
   /* background-color: white; */
   margin-top: 5px;
 }
-.iot{
+.iot {
   box-sizing: border-box;
   height: 41px;
   background-color: white;
   margin-bottom: 1%;
   border-radius: 5px;
 }
-.wrap-pktCapture-page{
-  display: flex; 
+.wrap-pktCapture-page {
+  display: flex;
   height: 100vh;
-  background-color: #F0F8FF;
+  background-color: #f0f8ff;
   padding: 1.5vh;
 }
-.sidebar{
+.sidebar {
   width: 370px;
   min-width: 285px;
   height: 100%;
   box-sizing: border-box;
 }
-.container{
+.container {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
 }
-
 
 .dashboard-data thead {
   display: none;
@@ -110,5 +110,4 @@ body {
   margin: 0;
   box-sizing: border-box;
 }
-
 </style>

--- a/src/page/iot-monitoring-page.vue
+++ b/src/page/iot-monitoring-page.vue
@@ -1,170 +1,211 @@
 <template>
-    <div class="container">
-        <Menubar :model="menuItems">
-          <template #start>
-            <img alt="logo" src="https://i.ibb.co/X2BdhfP/Kakao-Talk-20240510-171615462.png" height="40" class="mr-2">
-          </template>
-        </Menubar>
-    
-        <div class="spacer"></div>
-    
-      <div class="chart-container">
-        <OrganizationChart :value="data" class="chart">
-          <template #default="slotProps">
-      <div v-if="slotProps.node.data.image" class="node-header">
-        <img :src="slotProps.node.data.image" :alt="slotProps.node.data.title" class="node-image" />
-      </div>
-      <div v-else class="node-header">{{ slotProps.node.label }}</div>
-      <div class="node-content" :style="{ color: slotProps.node.data.is_transmitting ? 'green' : 'red' }">
-        <div class="node-text">{{ slotProps.node.data.title }}</div>
-        <div>{{ slotProps.node.data.email }}</div>
-      </div>
-    </template>
-        </OrganizationChart>
-      </div>
-    
-      <DataTable :value="iot" stripedRows class="custom-datatable">
-        <Column field="index" header="#" sortable style="width: 8%"></Column>
-        <Column field="mac" header="MAC" sortable style="width: 8%"></Column>
-        <Column field="ip" header="IP" sortable style="width: 8%"></Column>
-        <Column field="vendor" header="Vendor" sortable style="width: 8%"></Column>
-        <Column field="hostname" header="Hostname" sortable style="width: 8%"></Column>
-        <Column field="send_byte" header="송신 바이트" sortable style="width: 8%"></Column>
-        <Column field="receive_byte" header="수신 바이트" sortable style="width: 8%"></Column>
-        <Column field="send_packet" header="송신 패킷" sortable style="width: 8%"></Column>
-        <Column field="receive_packet" header="수신 패킷" sortable style="width: 8%"></Column>
-      </DataTable>
-      </div>
-    </template>
-    
-    <script setup>
-    import { ref, onMounted, watchEffect } from 'vue';
-    import DataTable from 'primevue/datatable';
-    import Column from 'primevue/column';
-    import OrganizationChart from 'primevue/organizationchart';
-    import Menubar from 'primevue/menubar';
-    
-    
-    const iot = ref([
-      { 
-        index: 1,
-        mac: '00:11:22:33:44:55',
-        ip: '192.168.1.1',
-        vendor: 'Vendor A',
-        hostname: 'Host 1',
-        send_byte: 100,
-        receive_byte: 200,
-        send_packet: 50,
-        receive_packet: 75,
-        is_transmitting: true,
-      },
-      { 
-        index: 2,
-        mac: 'AA:BB:CC:DD:EE:FF',
-        ip: '192.168.1.2',
-        vendor: 'Vendor B',
-        hostname: 'Host 2',
-        send_byte: 150,
-        receive_byte: 250,
-        send_packet: 75,
-        receive_packet: 100,
-        is_transmitting: false,
-      }
-    ]);
-    
-    const menuItems = ref([
-      {
-        label: 'IoT기기',
-      },
-      {
-        label: 'Public IP',
-      },
-      {
-        label: 'Private IP',
-      }
-    ]);
-    
-    
-    const data = {
-      key: '0',
+  <div class="container">
+    <Menubar :model="menuItems">
+      <template #start>
+        <img
+          alt="logo"
+          src="https://i.ibb.co/X2BdhfP/Kakao-Talk-20240510-171615462.png"
+          height="40"
+          class="mr-2"
+        />
+      </template>
+    </Menubar>
+
+    <div class="spacer"></div>
+
+    <div class="chart-container">
+      <OrganizationChart :value="data" class="chart">
+        <template #default="slotProps">
+          <div v-if="slotProps.node.data.image" class="node-header">
+            <img
+              :src="slotProps.node.data.image"
+              :alt="slotProps.node.data.title"
+              class="node-image"
+            />
+          </div>
+          <div v-else class="node-header">{{ slotProps.node.label }}</div>
+          <div
+            class="node-content"
+            :style="{
+              color: slotProps.node.data.is_transmitting ? 'green' : 'red',
+            }"
+          >
+            <div class="node-text">{{ slotProps.node.data.title }}</div>
+            <div>{{ slotProps.node.data.email }}</div>
+          </div>
+        </template>
+      </OrganizationChart>
+    </div>
+
+    <DataTable :value="iot" stripedRows class="custom-datatable">
+      <Column field="index" header="#" sortable style="width: 8%"></Column>
+      <Column field="mac" header="MAC" sortable style="width: 8%"></Column>
+      <Column field="ip" header="IP" sortable style="width: 8%"></Column>
+      <Column
+        field="vendor"
+        header="Vendor"
+        sortable
+        style="width: 8%"
+      ></Column>
+      <Column
+        field="hostname"
+        header="Hostname"
+        sortable
+        style="width: 8%"
+      ></Column>
+      <Column
+        field="send_byte"
+        header="송신 바이트"
+        sortable
+        style="width: 8%"
+      ></Column>
+      <Column
+        field="receive_byte"
+        header="수신 바이트"
+        sortable
+        style="width: 8%"
+      ></Column>
+      <Column
+        field="send_packet"
+        header="송신 패킷"
+        sortable
+        style="width: 8%"
+      ></Column>
+      <Column
+        field="receive_packet"
+        header="수신 패킷"
+        sortable
+        style="width: 8%"
+      ></Column>
+    </DataTable>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, watchEffect } from "vue";
+import DataTable from "primevue/datatable";
+import Column from "primevue/column";
+import OrganizationChart from "primevue/organizationchart";
+import Menubar from "primevue/menubar";
+
+const iot = ref([
+  {
+    index: 1,
+    mac: "00:11:22:33:44:55",
+    ip: "192.168.1.1",
+    vendor: "Vendor A",
+    hostname: "Host 1",
+    send_byte: 100,
+    receive_byte: 200,
+    send_packet: 50,
+    receive_packet: 75,
+    is_transmitting: true,
+  },
+  {
+    index: 2,
+    mac: "AA:BB:CC:DD:EE:FF",
+    ip: "192.168.1.2",
+    vendor: "Vendor B",
+    hostname: "Host 2",
+    send_byte: 150,
+    receive_byte: 250,
+    send_packet: 75,
+    receive_packet: 100,
+    is_transmitting: false,
+  },
+]);
+
+const menuItems = ref([
+  {
+    label: "IoT기기",
+  },
+  {
+    label: "Public IP",
+  },
+  {
+    label: "Private IP",
+  },
+]);
+
+const data = {
+  key: "0",
+  data: {
+    image: "https://i.ibb.co/VQGjYtS/laptop.png",
+  },
+  children: generateChildNodes(iot.value.length),
+};
+
+function fetchNewData() {
+  // 데이터를 가져오는 로직을 이곳에 구현합니다.
+  // 현재는 빈 배열을 반환합니다.
+  const newData = [];
+  iot.value = [...iot.value, ...newData];
+}
+
+function generateChildNodes(count) {
+  const childNodes = [];
+  for (let i = 1; i <= count; i++) {
+    childNodes.push({
+      key: `0-${i}`,
       data: {
-        image: 'https://i.ibb.co/VQGjYtS/laptop.png',
+        title: `${i}`,
       },
-      children: generateChildNodes(iot.value.length),
-    };
-    
-    function fetchNewData() {
-      // 데이터를 가져오는 로직을 이곳에 구현합니다.
-      // 현재는 빈 배열을 반환합니다.
-      const newData = [];
-      iot.value = [...iot.value, ...newData];
-    }
-    
-    function generateChildNodes(count) {
-      const childNodes = [];
-      for (let i = 1; i <= count; i++) {
-        childNodes.push({
-          key: `0-${i}`,
-          data: {
-            title: `${i}`,
-          },
-        });
-      }
-      return childNodes;
-    }
-    
-    // 컴포넌트가 마운트될 때 초기 데이터를 가져오고 조직도의 자식 노드를 동적으로 생성합니다.
-    onMounted(() => {
-      fetchNewData();
-      data.children = generateChildNodes(iot.value.length);
     });
-    
-    // iot 데이터가 변경될 때마다 조직도의 자식 노드를 업데이트합니다.
-    watchEffect(() => {
-      data.children = generateChildNodes(iot.value.length);
-    });
-    </script>
-    
-    <style scoped>
-    .container {
-      width: 100%;
-      max-width: 1200px; /* 페이지의 최대 너비를 제한합니다. */
-      margin: 0 auto; /* 페이지를 가운데 정렬합니다. */
-    }
-    
-    .chart-container {
-      display: flex;
-      justify-content: center; /* 상위 노드를 가운데 정렬합니다. */
-    }
-    
-    .chart {
-      display: inline-block;
-      text-align: left; /* 하위 노드를 좌측 정렬합니다. */
-      max-width: 100%; /* 최대 너비를 설정합니다. */
-      overflow-x: auto; /* 필요한 경우에만 가로 스크롤을 활성화합니다. */
-      white-space: nowrap; /* 내용이 한 줄로 유지되도록 설정합니다. */
-    }
-    
-    .custom-datatable .p-datatable-tbody > tr > td {
-      border-bottom: 1px solid #ccc;
-      width: 100%;
-    }
-    
-    .chart .p-organizationchart-node-content {
-      padding: 0.5rem; /* 노드 내부 여백을 줄입니다. */
-    }
-    
-    .node-text {
-      font-size: 1rem; /* 노드 텍스트의 폰트 크기를 조절합니다. */
-    }
-    
-    .node-image {
-      max-width: 30px;
-      max-height: 30px;
-    }
-    
-    .spacer {
-      height: 20px; /* 원하는 여백의 높이로 조정하세요 */
-    }
-    </style>
-    
+  }
+  return childNodes;
+}
+
+// 컴포넌트가 마운트될 때 초기 데이터를 가져오고 조직도의 자식 노드를 동적으로 생성합니다.
+onMounted(() => {
+  fetchNewData();
+  data.children = generateChildNodes(iot.value.length);
+});
+
+// iot 데이터가 변경될 때마다 조직도의 자식 노드를 업데이트합니다.
+watchEffect(() => {
+  data.children = generateChildNodes(iot.value.length);
+});
+</script>
+
+<style scoped>
+.container {
+  width: 100%;
+  max-width: 1200px; /* 페이지의 최대 너비를 제한합니다. */
+  margin: 0 auto; /* 페이지를 가운데 정렬합니다. */
+}
+
+.chart-container {
+  display: flex;
+  justify-content: center; /* 상위 노드를 가운데 정렬합니다. */
+}
+
+.chart {
+  display: inline-block;
+  text-align: left; /* 하위 노드를 좌측 정렬합니다. */
+  max-width: 100%; /* 최대 너비를 설정합니다. */
+  overflow-x: auto; /* 필요한 경우에만 가로 스크롤을 활성화합니다. */
+  white-space: nowrap; /* 내용이 한 줄로 유지되도록 설정합니다. */
+}
+
+.custom-datatable .p-datatable-tbody > tr > td {
+  border-bottom: 1px solid #ccc;
+  width: 100%;
+}
+
+.chart .p-organizationchart-node-content {
+  padding: 0.5rem; /* 노드 내부 여백을 줄입니다. */
+}
+
+.node-text {
+  font-size: 1rem; /* 노드 텍스트의 폰트 크기를 조절합니다. */
+}
+
+.node-image {
+  max-width: 30px;
+  max-height: 30px;
+}
+
+.spacer {
+  height: 20px; /* 원하는 여백의 높이로 조정하세요 */
+}
+</style>


### PR DESCRIPTION
## issue
#5 #14 

## Details
* SUBSCRIBE / SUBACK / UNSUBSCRIBE / UNSUBACK -> 다이어그램 나올수있는 코드 추가
* row가 1byte / column이 1bit 로 다이어그램 구현
* 한 줄이 1byte로 나오게 만듬. 2바이트인 경우는 2줄이 되게 -> 추후에 선을 (1byte씩 구분되게) 추가할 수 있게 만드는게 나을거같음
* topic이나 msg등 바이트 크기가 가변적인거는 1바이트씩 줄을 만들게 되면 가독성이 좋지 않은거 같아서 title 옆에 ( ~ byte )로 크기를 표시함.

### CONNECT
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/84d586d4-b378-435b-9f78-c9637403d257)
### CONNACK
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/50fd5361-51cf-4d6f-b369-4d24241c2c37) 

### SUBSCRIBE 
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/5a4effcb-b32a-4d53-9ad8-335e982f8138)
### SUBACK
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/1f3d447b-61e0-44b2-af4d-da70936849d7)

### PUBLISH 
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/d935bf65-13ca-4209-ac2d-0e3effde16a4)
### PUBCOMP
![image](https://github.com/Wave-Net/wavenet-frontend/assets/153170795/5f96edf0-cbb5-487f-bc27-44da812d1246)