### PR TITLE
fix: 패킷 그래프 범위 max값 업데이트 로직 수정 #86

### DIFF
--- a/src/components/PacketGraph.vue
+++ b/src/components/PacketGraph.vue
@@ -63,21 +63,42 @@ const updateTotal = (newStatMessage: any) => {
   totalStat.sendData += newStatMessage.send_data;
 };
 
-const updateArray = (array: any, value: number, maxValue: Ref<number>) => {
+const updateArray = (array: any, value: number) => {
   const newArray =
     array.value.length >= MAX_LENGTH ? array.value.slice(1) : [...array.value];
   array.value = [...newArray, value];
-  maxValue.value = Math.max(...array.value.map(Math.abs));
+};
+
+const updateArraysAndMax = (
+  recvArray: Ref<number[]>,
+  sendArray: Ref<number[]>,
+  recvValue: number,
+  sendValue: number
+) => {
+  updateArray(recvArray, recvValue);
+  updateArray(sendArray, sendValue);
+  return Math.max(
+    ...recvArray.value.map(Math.abs),
+    ...sendArray.value.map(Math.abs)
+  );
 };
 
 watch(
   () => captureStore.statMessage,
   (newStatMessage) => {
     if (newStatMessage) {
-      updateArray(recvPktArray, newStatMessage.recv_pkt, pktMax);
-      updateArray(sendPktArray, newStatMessage.send_pkt, pktMax);
-      updateArray(recvDataArray, newStatMessage.recv_data, dataMax);
-      updateArray(sendDataArray, newStatMessage.send_data, dataMax);
+      pktMax.value = updateArraysAndMax(
+        recvPktArray,
+        sendPktArray,
+        newStatMessage.recv_pkt,
+        newStatMessage.send_pkt
+      );
+      dataMax.value = updateArraysAndMax(
+        recvDataArray,
+        sendDataArray,
+        newStatMessage.recv_data,
+        newStatMessage.send_data
+      );
 
       updateTotal(newStatMessage);
     }

--- a/src/pages/CapturePage.vue
+++ b/src/pages/CapturePage.vue
@@ -7,9 +7,7 @@
           <MenuButton :device-ip="deviceIp" />
         </div>
         <div class="row mt-2">
-          <div class="col-12">
-            <PacketGraph />
-          </div>
+          <PacketGraph />
         </div>
       </SplitterPanel>
       <SplitterPanel id="splitter-1-panel-2" :size="85">


### PR DESCRIPTION
## Issue
#86 

## Details
``recvPktArray``, ``sendPktArray``
``sendDataArray``, ``sendDataArray`` 에서 각각 ``pktMax``, ``dataMax`` 값을 업데이트 해서 생간 문제였음

결국 sendArray의 max 값으로 범위가 정해졌던 것.

``recvPktArray, sendPktArray``을 묶어서 ``ptkMax`` 값을 정하고
``sendDataArray, sendDataArray``을 묶어서 ``dataMax`` 값을 정하도록 수정

<img width="191" alt="image" src="https://github.com/Wave-Net/wavenet-frontend/assets/52701529/47ea0b2b-93ae-451c-bbf1-d463f0f67c3f">
